### PR TITLE
Remove cleanup of lines in stacktrace

### DIFF
--- a/lib/onlyoffice_testrail_wrapper/helpers/string_helper.rb
+++ b/lib/onlyoffice_testrail_wrapper/helpers/string_helper.rb
@@ -5,10 +5,6 @@ module OnlyofficeTestrailWrapper
         warn 'Beginning or end of string has spaces! In: ' + string unless string == string.strip
         string.strip
       end
-
-      def get_string_elements_from_array(array, parameter, full_equality = false)
-        array.select { |element| full_equality ? element == parameter : element.include?(parameter) }
-      end
     end
   end
 end

--- a/lib/onlyoffice_testrail_wrapper/testrail_helper.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_helper.rb
@@ -103,11 +103,7 @@ module OnlyofficeTestrailWrapper
       else
         result = :aborted
         comment += "\n" + exception.to_s
-        unless exception.backtrace.nil?
-          lines = StringHelper.get_string_elements_from_array(exception.backtrace, 'RubymineProjects')
-          lines.each_with_index { |e, i| lines[i] = e.to_s.sub(%r{.*RubymineProjects/}, '').gsub('`', " '") }
-          custom_fields[:custom_autotest_error_line] = lines.join("\r\n")
-        end
+        custom_fields[:custom_autotest_error_line] = exception.backtrace.join("\n") unless exception.backtrace.nil?
       end
       @last_case = example.description
       @suite.section(section_name).case(example.description).add_result @run.id, result, comment, custom_fields


### PR DESCRIPTION
This code work well while whole code was in real folders.
But since a lot of code moved to gems, like webdriver wrapper, in not usefull
because this old code hide all stacktraces from gems.
So before this commit stacktrace looked like this:
```
Autotest Error Log
OnlineDocuments/framework/portals/portal_operation.rb:87:in 'new'
OnlineDocuments/framework/portals/portal_operation.rb:87:in 'init_session'
OnlineDocuments/framework/portals/portal_operation.rb:144:in 'init_and_create_my_file_and_open_in_editor'
OnlineDocuments/framework/portals/portal_operation.rb:111:in 'create_file_and_open'
OnlineDocuments/spec/studio/run_test_single_spec.rb:12:in 'block (2 levels) in <top (required)>'
```
Error actually caused by gem was not included in this. So stacktraces will be much longer,
but more usefull.

See result in http://testrail-nct.tk/testrail/index.php?/tests/view/29350779