### PR TITLE
move :custom_autotest_error_line to custom field creator method.

### DIFF
--- a/lib/onlyoffice_testrail_wrapper/testrail_helper.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_helper.rb
@@ -104,7 +104,6 @@ module OnlyofficeTestrailWrapper
       else
         result = :aborted
         comment += "\n" + exception.to_s
-        custom_fields[:custom_autotest_error_line] = exception.backtrace.join("\n") unless exception.backtrace.nil?
       end
       @last_case = example.description
       @suite.section(section_name).case(example.description).add_result @run.id, result, comment, custom_fields

--- a/lib/onlyoffice_testrail_wrapper/testrail_helper/testrail_helper_rspec_metadata.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_helper/testrail_helper_rspec_metadata.rb
@@ -19,7 +19,10 @@ module OnlyofficeTestrailWrapper
       custom_fields[:elapsed] = example_time_in_seconds(example)
       custom_fields[:version] = version || @plan.try(:name)
       custom_fields[:custom_host] = SystemHelper.hostname
-      custom_fields[:custom_screenshot_link] = screenshot_link if example.exception
+      if example.exception
+        custom_fields[:custom_autotest_error_line] = example.exception.backtrace.join("\n") unless example.exception.backtrace.nil?
+        custom_fields[:custom_screenshot_link] = screenshot_link unless screenshot_link.nil?
+      end
       custom_fields
     end
 
@@ -27,7 +30,7 @@ module OnlyofficeTestrailWrapper
     # empty string if not supported
     def screenshot_link
       return AppManager.create_screenshots if AppManager.respond_to?(:create_screenshots)
-      ''
+      nil
     end
 
     def parse_pending_comment(pending_message)


### PR DESCRIPTION
Add new check for :custom_screenshot_link set - set screenshot link if it exist
Edit return of screenshot_link method: nw, it well return nil and not empty struing (""). it is rightly, because if link is not exist - link is not exist completely.