### PR TITLE
Remove unused `custom_js_error` handler

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,12 +1,14 @@
 # Change log
 
 ## master (unreleased)
+
 ### Changes
 * Change method `get_tests_by_result` for working with array of statuses
 * Extract `Bugzilla` helpers to separate gem `onlyoffice_bugzilla_helper`
 * Drop support of Ruby 2.1
 * Add plan url for error while adding result to closed plan
 * Remove dependency of `activesupport`
+* Remove unused `custom_js_error` handler
 
 ### Fixes
 * Fix problem with adding result to testrail if test took less than 1 second

--- a/lib/onlyoffice_testrail_wrapper/testrail_helper/testrail_helper_rspec_metadata.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail_helper/testrail_helper_rspec_metadata.rb
@@ -24,7 +24,6 @@ module OnlyofficeTestrailWrapper
       # TODO: Fix dependencies from other project
       return custom_fields if defined?(AppManager).nil?
 
-      custom_fields[:custom_js_error] = WebDriver.web_console_error unless WebDriver.web_console_error.nil?
       custom_fields[:elapsed] = example_time_in_seconds(example)
       custom_fields[:version] = version
       custom_fields[:custom_host] = SystemHelper.hostname


### PR DESCRIPTION
Leftovers of this feature removed in https://github.com/onlyoffice-testing-robot/onlyoffice_webdriver_wrapper/pull/181

Seems this feature was not used at all at any time in history