### PR TITLE
Remove `net-ping` dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 * Remove dependency of `activesupport`
 * Remove unused `custom_js_error` handler
 * Required ruby version is 2.3
+* Remove `net-ping` dependency
 
 ### Fixes
 * Fix problem with adding result to testrail if test took less than 1 second

--- a/lib/onlyoffice_testrail_wrapper/testrail.rb
+++ b/lib/onlyoffice_testrail_wrapper/testrail.rb
@@ -5,7 +5,6 @@
 
 require 'net/http'
 require 'json'
-require 'net/ping'
 require 'yaml'
 require_relative 'testrail_project'
 

--- a/onlyoffice_testrail_wrapper.gemspec
+++ b/onlyoffice_testrail_wrapper.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.email = ['shockwavenn@gmail.com', 'rzagudaev@gmail.com']
   s.files = `git ls-files lib LICENSE.txt README.md`.split($RS)
   s.homepage = 'https://github.com/onlyoffice-testing-robot/onlyoffice_testrail_wrapper'
-  s.add_runtime_dependency('net-ping', '~> 2')
   s.add_runtime_dependency('onlyoffice_bugzilla_helper', '~> 0.1')
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')
   s.license = 'AGPL-3.0'


### PR DESCRIPTION
Don't know why it was used at all

And seems it cause trouble with loading timeouts on this line:
https://github.com/eitoball/net-ping/blob/master/lib/net/ping.rb#L16

(Also don't know why, just seems that this line is hangup on execution)